### PR TITLE
Use std::vector::data to avoid dereferencing 0-length vectors

### DIFF
--- a/src/vectorization/VerletList.cpp
+++ b/src/vectorization/VerletList.cpp
@@ -155,14 +155,14 @@ namespace espressopp { namespace vectorization {
     {
       const auto& cellNborList            = vec->getNeighborList();
       const auto& particleArray           = vec->getParticleArray();
-      const size_t* __restrict cellRange = &(particleArray.cellRange()[0]);
-      const size_t* __restrict sizes      = &(particleArray.sizes()[0]);
+      const size_t* __restrict cellRange  = particleArray.cellRange().data();
+      const size_t* __restrict sizes      = particleArray.sizes().data();
 
-      const auto* __restrict position  = &(particleArray.position[0]);
-      const auto* __restrict pa_p_x    = &(particleArray.p_x[0]);
-      const auto* __restrict pa_p_y    = &(particleArray.p_y[0]);
-      const auto* __restrict pa_p_z    = &(particleArray.p_z[0]);
-      const auto* __restrict pa_p_type = &(particleArray.type[0]);
+      const auto* __restrict position  = particleArray.position.data();
+      const auto* __restrict pa_p_x    = particleArray.p_x.data();
+      const auto* __restrict pa_p_y    = particleArray.p_y.data();
+      const auto* __restrict pa_p_z    = particleArray.p_z.data();
+      const auto* __restrict pa_p_type = particleArray.type.data();
 
       // number of cells with neighbors
       const size_t numRealCells = cellNborList.numCells();
@@ -206,10 +206,10 @@ namespace espressopp { namespace vectorization {
         }
       }
 
-      auto* __restrict c_x_ptr = &(c_x[0]);
-      auto* __restrict c_y_ptr = &(c_y[0]);
-      auto* __restrict c_z_ptr = &(c_z[0]);
-      auto* __restrict c_j_ptr = &(c_j[0]);
+      auto* __restrict c_x_ptr = c_x.data();
+      auto* __restrict c_y_ptr = c_y.data();
+      auto* __restrict c_z_ptr = c_z.data();
+      auto* __restrict c_j_ptr = c_j.data();
       int c_j_max = 0;
 
       if(PACK_NEIGHBORS)

--- a/src/vectorization/interaction/VerletListLennardJones.hpp
+++ b/src/vectorization/interaction/VerletListLennardJones.hpp
@@ -192,21 +192,21 @@ namespace espressopp { namespace vectorization {
         auto& particleArray = verletList->getParticleArray();
         auto& neighborList = verletList->getNeighborList();
 
-        const Real3DInt *pa_pos  = &(particleArray.position[0]);
-        Real4D *pa_force         = &(particleArray.force[0]);
+        const Real3DInt *pa_pos  = particleArray.position.data();
+        Real4D *pa_force         = particleArray.force.data();
 
-        const ulongint* __restrict pa_type = &(particleArray.type[0]);
-        const real* __restrict pa_p_x = &(particleArray.p_x[0]);
-        const real* __restrict pa_p_y = &(particleArray.p_y[0]);
-        const real* __restrict pa_p_z = &(particleArray.p_z[0]);
-        real* __restrict pa_f_x       = &(particleArray.f_x[0]);
-        real* __restrict pa_f_y       = &(particleArray.f_y[0]);
-        real* __restrict pa_f_z       = &(particleArray.f_z[0]);
+        const ulongint* __restrict pa_type = particleArray.type.data();
+        const real* __restrict pa_p_x = particleArray.p_x.data();
+        const real* __restrict pa_p_y = particleArray.p_y.data();
+        const real* __restrict pa_p_z = particleArray.p_z.data();
+        real* __restrict pa_f_x       = particleArray.f_x.data();
+        real* __restrict pa_f_y       = particleArray.f_y.data();
+        real* __restrict pa_f_z       = particleArray.f_z.data();
 
         {
-          const auto* __restrict plist  = &(neighborList.plist[0]);
-          const auto* __restrict prange = &(neighborList.prange[0]);
-          const auto* __restrict nplist = &(neighborList.nplist[0]);
+          const auto* __restrict plist  = neighborList.plist.data();
+          const auto* __restrict prange = neighborList.prange.data();
+          const auto* __restrict nplist = neighborList.nplist.data();
           const int ip_max = neighborList.plist.size();
 
           int in_min=0;


### PR DESCRIPTION
Fixes broken vectorization test